### PR TITLE
Pass filename option to jade.compileClient

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -2,12 +2,13 @@ jade = require 'react-jade'
 through = require 'through2'
 replaceExt = require 'replace-ext'
 
-module.exports = (opt) ->
+module.exports = (opt = {}) ->
   stream = through.obj (file, enc, callback) ->
     if file.isNull()
       @push(file)
       return callback()
     else if file.isBuffer()
+      opt['filename'] = file.path
       templateString = jade.compileClient(file.contents.toString(), opt).toString()
       file.contents = new Buffer 'module.exports = ' + templateString
       file.path = replaceExt(file.path, '.js')

--- a/index.js
+++ b/index.js
@@ -10,12 +10,16 @@
 
   module.exports = function(opt) {
     var stream;
+    if (opt == null) {
+      opt = {};
+    }
     stream = through.obj(function(file, enc, callback) {
       var templateString;
       if (file.isNull()) {
         this.push(file);
         return callback();
       } else if (file.isBuffer()) {
+        opt['filename'] = file.path;
         templateString = jade.compileClient(file.contents.toString(), opt).toString();
         file.contents = new Buffer('module.exports = ' + templateString);
         file.path = replaceExt(file.path, '.js');


### PR DESCRIPTION
When I use `include` tag with relative path in my jade file, I got following error:

```
the "filename" option is required to use "include" with "relative" paths
  at Parser.resolvePath (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:465:13)
  at Parser.parseInclude (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:564:21)
  at Parser.parseExpr (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:223:21)
  at Parser.block (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:708:25)
  at Parser.tag (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:817:24)
  at Parser.parseTag (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:738:17)
  at Parser.parseExpr (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:211:21)
  at Parser.parseExpr (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:250:21)
  at Parser.block (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:708:25)
  at Parser.tag (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:817:24)
  at Parser.parseTag (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:738:17)
  at Parser.parseExpr (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:211:21)
  at Parser.parseExpr (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:250:21)
  at Parser.block (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:708:25)
  at Parser.tag (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:817:24)
  at Parser.parseTag (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:738:17)
  at Parser.parseExpr (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:211:21)
  at Parser.block (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:708:25)
  at Parser.parseEach (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:440:23)
  at Parser.parseExpr (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:233:21)
  at Parser.block (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:708:25)
  at Parser.tag (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:817:24)
  at Parser.parseTag (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:738:17)
  at Parser.parseExpr (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:211:21)
  at Parser.parseExpr (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:250:21)
  at Parser.block (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:708:25)
  at Parser.parseCode (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:361:25)
  at Parser.parseExpr (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:235:21)
  at Parser.block (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:708:25)
  at Parser.tag (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:817:24)
  at Parser.parseTag (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:738:17)
  at Parser.parseExpr (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:211:21)
  at Parser.parseExpr (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:250:21)
  at Parser.block (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:708:25)
  at Parser.tag (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:817:24)
  at Parser.parseTag (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:738:17)
  at Parser.parseExpr (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:211:21)
  at Parser.parseExpr (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:250:21)
  at Parser.parse (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/node_modules/jade/lib/parser.js:122:25)
  at parse (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/lib/parse.js:25:21)
  at Function.compileClient (/myapp/node_modules/@mizchi/gulp-react-jade/node_modules/react-jade/lib/compile-client.js:25:7)
  at DestroyableTransform._transform (/myapp/node_modules/@mizchi/gulp-react-jade/index.js:19:31)
  .
  .
  .
```

So I just pass this required option to `jade.compileClient()`. Would you confirm and merge it?
